### PR TITLE
CI complains about the presense of php version check

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
   "require": {
-    "php": "<=5.5.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "4e2c29f82b62c8c091e8d2ec148bde4f",
+    "hash": "d691ab2af01524465babaf420b9964a9",
     "packages": [],
     "packages-dev": [
         {
@@ -1406,8 +1406,6 @@
     "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": {
-        "php": "<=5.5.0"
-    },
+    "platform": [],
     "platform-dev": []
 }


### PR DESCRIPTION
Loading composer repositories with package information
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - The requested package php could not be found in any version, there may be a typo in the package name.
  Problem 2
    - The requested package php could not be found in any version, there may be a typo in the package name.
  Problem 3
    - Installation request for fzaninotto/faker v1.4.0 -> satisfiable by fzaninotto/faker[v1.4.0].
    - fzaninotto/faker v1.4.0 requires php >=5.3.3 -> no matching package found.
  Problem 4
    - phpunit/phpunit 4.4.5 requires php >=5.3.3 -> no matching package found.
    - phpunit/phpunit 4.4.4 requires php >=5.3.3 -> no matching package found.
    - phpunit/phpunit 4.4.3 requires php >=5.3.3 -> no matching package found.
    - phpunit/phpunit 4.4.2 requires php >=5.3.3 -> no matching package found.
    - phpunit/phpunit 4.4.1 requires php >=5.3.3 -> no matching package found.
    - phpunit/phpunit 4.4.0 requires php >=5.3.3 -> no matching package found.
    - Installation request for phpunit/phpunit ~4.4 -> satisfiable by phpunit/phpunit[4.4.0, 4.4.1, 4.4.2, 4.4.3, 4.4.4, 4.4.5].

Potential causes:
 - A typo in the package name
 - The package is not available in a stable-enough version according to your minimum-stability setting
   see <https://groups.google.com/d/topic/composer-dev/_g3ASeIFlrc/discussion> for more details.

Read <http://getcomposer.org/doc/articles/troubleshooting.md> for further common problems.